### PR TITLE
Update build actions

### DIFF
--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup .NET 8.0.x
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
     - name: Restore solution

--- a/.github/workflows/master-publish.yml
+++ b/.github/workflows/master-publish.yml
@@ -15,9 +15,9 @@ jobs:
         VERSION=${{ github.event.release.tag_name }}
         echo "VERSION=${VERSION#v}" >> $GITHUB_ENV
     - name: Checkout source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup .NET 8.0.x
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
     - name: Restore solution

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup .NET 8.0.x
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
     - name: Restore solution


### PR DESCRIPTION
Updated build actions to v4 to avoid build warnings on deprecated nodejs version used by old actions.