### PR TITLE
Add additional headers support

### DIFF
--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
-    - name: Setup .NET 8.0.x
+    - name: Setup .NET 9.0.x
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
     - name: Restore solution
       run: dotnet restore
     - name: Build solution

--- a/.github/workflows/master-publish.yml
+++ b/.github/workflows/master-publish.yml
@@ -16,10 +16,10 @@ jobs:
         echo "VERSION=${VERSION#v}" >> $GITHUB_ENV
     - name: Checkout source
       uses: actions/checkout@v4
-    - name: Setup .NET 8.0.x
+    - name: Setup .NET 9.0.x
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
     - name: Restore solution
       run: dotnet restore
     - name: Build solution (pre-release)

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
-    - name: Setup .NET 8.0.x
+    - name: Setup .NET 9.0.x
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
     - name: Restore solution
       run: dotnet restore
     - name: Build solution

--- a/.gitignore
+++ b/.gitignore
@@ -344,5 +344,8 @@ healthchecksdb
 /test/coverage.opencover.xml
 /test/result.json
 
+# POC related
+/poc
+
 # Custom exclusions
 *.AssemblyAttributes

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Using OAuth2 client credentials, all settings except `DisableTokenCache` and `Sc
 "<section name>": {
   "AuthenticationProvider": "OAuth2",
   "OAuth2": {
-    "AuthorizationEndpoint": "<OAuth2 token endpoint>",
     "DisableTokenCache": false,
     "GrantType": "ClientCredentials",
     "Scope": "<Optional scopes separated by space>",
+    "TokenEndpoint": "<OAuth2 token endpoint>",
     "ClientCredentials": {
         "ClientId": "<Unique client id>",
         "ClientSecret": "<Secret connected to the client id>"
@@ -88,6 +88,8 @@ Using OAuth2 client credentials, all settings except `DisableTokenCache` and `Sc
 }
 ```
 
+> **NOTE**: The previous `AuthorizationEndpoint` is replaced by `TokenEndpoint`. It still exists,
+but is obsoleted and will be removed in a later version.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Authentication using OAuth2.
 
 ##### Client credentials
 
-Using OAuth2 client credentials, all settings except `DisableTokenCache` and `Scope` is required.
+Using OAuth2 client credentials, all settings except `DisableTokenCache`, `Scope` and
+`TokenEndpoint`'s `Additional*Parameters` is required.
 
 ```
 "<section name>": {
@@ -79,7 +80,15 @@ Using OAuth2 client credentials, all settings except `DisableTokenCache` and `Sc
     "DisableTokenCache": false,
     "GrantType": "ClientCredentials",
     "Scope": "<Optional scopes separated by space>",
-    "TokenEndpoint": "<OAuth2 token endpoint>",
+    "TokenEndpoint": {
+        "Url": "<OAuth2 token endpoint>",
+        "AdditionalHeaderParameters": {
+        },
+        "AdditionalBodyParameters": {
+        },
+        "AdditionalQueryParameters": {
+        }
+    },
     "ClientCredentials": {
         "ClientId": "<Unique client id>",
         "ClientSecret": "<Secret connected to the client id>"
@@ -88,8 +97,9 @@ Using OAuth2 client credentials, all settings except `DisableTokenCache` and `Sc
 }
 ```
 
-> **NOTE**: The previous `AuthorizationEndpoint` is replaced by `TokenEndpoint`. It still exists,
-but is obsoleted and will be removed in a later version.
+The `Additional*Parameters` configuration is dynamic, any configuration in these will 
+be added to their respective parts of the request accordingly. Please note that the 
+`AdditionalQueryParameters` will be url encoded.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,6 @@ The package currently supports the following authentication methods:
 - OAuth2
   - Client credentials
 
-> Please note: The .NET Standard 2.0 and .NET 6 targeted packages references the LTS version 6 of the dependent 
-NuGet packages. The reason for this is that while it is possible to run .NET 7 NuGet packages on .NET 6, it is known that some 
-of them may introduce unexpected behavior. It is recommended (especially from the ASP.NET Core team) limit usage of .NET 7 
-based NuGet packages on .NET 6 runtime.
-
 ## USAGE
 
 Add the NuGet package `KISS.HttpClientAuthentication` to your project and whenever a 

--- a/src/HttpClientAuthentication/AssemblyInfo.cs
+++ b/src/HttpClientAuthentication/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using System.Runtime.CompilerServices;

--- a/src/HttpClientAuthentication/Configuration/ApiKeyConfiguration.cs
+++ b/src/HttpClientAuthentication/Configuration/ApiKeyConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 namespace KISS.HttpClientAuthentication.Configuration

--- a/src/HttpClientAuthentication/Configuration/BasicConfiguration.cs
+++ b/src/HttpClientAuthentication/Configuration/BasicConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 namespace KISS.HttpClientAuthentication.Configuration

--- a/src/HttpClientAuthentication/Configuration/ClientCredentialsConfiguration.cs
+++ b/src/HttpClientAuthentication/Configuration/ClientCredentialsConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 namespace KISS.HttpClientAuthentication.Configuration

--- a/src/HttpClientAuthentication/Configuration/HttpClientAuthenticationConfiguration.cs
+++ b/src/HttpClientAuthentication/Configuration/HttpClientAuthenticationConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using KISS.HttpClientAuthentication.Constants;

--- a/src/HttpClientAuthentication/Configuration/OAuth2Configuration.cs
+++ b/src/HttpClientAuthentication/Configuration/OAuth2Configuration.cs
@@ -14,7 +14,11 @@ namespace KISS.HttpClientAuthentication.Configuration
         ///     Gets or sets the authorization endpoint used by some <see cref="AuthenticationProvider"/>
         ///     configuration.
         /// </summary>
-        public Uri AuthorizationEndpoint { get; set; } = default!;
+        /// <remarks>
+        ///     Obsolete: Use <see cref="TokenEndpoint"/> instead.
+        /// </remarks>
+        [Obsolete("Use TokenEndpoint instead.")]
+        public Uri AuthorizationEndpoint { get => TokenEndpoint; set => TokenEndpoint = value; }
 
         /// <summary>
         ///     Gets or sets the authorization scheme to use if <see cref="AuthenticationHeader"/> is 
@@ -47,5 +51,13 @@ namespace KISS.HttpClientAuthentication.Configuration
         ///     Scopes must be separated with a space.
         /// </remarks>
         public string? Scope { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the token endpoint.
+        /// </summary>
+        /// <remarks>
+        ///     Replaces <see cref="AuthorizationEndpoint"/>.
+        /// </remarks>
+        public Uri TokenEndpoint { get; set; } = default!;
     }
 }

--- a/src/HttpClientAuthentication/Configuration/OAuth2Configuration.cs
+++ b/src/HttpClientAuthentication/Configuration/OAuth2Configuration.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using KISS.HttpClientAuthentication.Constants;

--- a/src/HttpClientAuthentication/Configuration/OAuth2Configuration.cs
+++ b/src/HttpClientAuthentication/Configuration/OAuth2Configuration.cs
@@ -11,16 +11,6 @@ namespace KISS.HttpClientAuthentication.Configuration
     public sealed class OAuth2Configuration
     {
         /// <summary>
-        ///     Gets or sets the authorization endpoint used by some <see cref="AuthenticationProvider"/>
-        ///     configuration.
-        /// </summary>
-        /// <remarks>
-        ///     Obsolete: Use <see cref="TokenEndpoint"/> instead.
-        /// </remarks>
-        [Obsolete("Use TokenEndpoint instead.")]
-        public Uri AuthorizationEndpoint { get => TokenEndpoint; set => TokenEndpoint = value; }
-
-        /// <summary>
         ///     Gets or sets the authorization scheme to use if <see cref="AuthenticationHeader"/> is 
         ///     Authorization or the selected <see cref="AuthenticationProvider"/> uses Authorization as default header.
         ///     
@@ -58,6 +48,6 @@ namespace KISS.HttpClientAuthentication.Configuration
         /// <remarks>
         ///     Replaces <see cref="AuthorizationEndpoint"/>.
         /// </remarks>
-        public Uri TokenEndpoint { get; set; } = default!;
+        public OAuth2Endpoint TokenEndpoint { get; set; } = default!;
     }
 }

--- a/src/HttpClientAuthentication/Configuration/OAuth2Endpoint.cs
+++ b/src/HttpClientAuthentication/Configuration/OAuth2Endpoint.cs
@@ -1,0 +1,40 @@
+// Copyright © 2025 Rune Gulbrandsen.
+// All rights reserved. Licensed under the MIT License; see LICENSE.txt.
+
+namespace KISS.HttpClientAuthentication.Configuration
+{
+    /// <summary>
+    ///     Endpoint configuration for OAuth2 endpoints
+    /// </summary>
+    public sealed partial class OAuth2Endpoint
+    {
+        /// <summary>
+        ///     Gets or sets the Url to the OAuth2 endpoint.
+        /// </summary>
+        public Uri Url { get; set; } = default!;
+
+        /// <summary>
+        ///     Gets a dictionary that can contain additional headers that will be
+        ///     supplied when requesting <see cref="Url"/>.
+        /// </summary>
+        public Dictionary<string, string> AdditionalHeaderParameters { get; } = [];
+
+
+        /// <summary>
+        ///     Gets a collection of additional form body parameters that will be
+        ///     supplied when requesting <see cref="Url"/>.
+        /// </summary>
+        public Dictionary<string, string> AdditionalBodyParameters { get; } = [];
+
+        /// <summary>
+        ///     Gets a collection of additional query string parameters that will
+        ///     be supplied when requesting <see cref="Url"/>.
+        /// </summary>
+        public Dictionary<string, string> AdditionalQueryParameters { get; } = [];
+
+        public override string ToString()
+        {
+            return Url.ToString();
+        }
+    }
+}

--- a/src/HttpClientAuthentication/Constants/AuthenticationProvider.cs
+++ b/src/HttpClientAuthentication/Constants/AuthenticationProvider.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 namespace KISS.HttpClientAuthentication.Constants

--- a/src/HttpClientAuthentication/Constants/OAuth2GrantType.cs
+++ b/src/HttpClientAuthentication/Constants/OAuth2GrantType.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 namespace KISS.HttpClientAuthentication.Constants

--- a/src/HttpClientAuthentication/Constants/OAuth2Keyword.cs
+++ b/src/HttpClientAuthentication/Constants/OAuth2Keyword.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 namespace KISS.HttpClientAuthentication.Constants

--- a/src/HttpClientAuthentication/Handlers/ApiKeyAuthenticationHandler.cs
+++ b/src/HttpClientAuthentication/Handlers/ApiKeyAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using KISS.HttpClientAuthentication.Configuration;

--- a/src/HttpClientAuthentication/Handlers/BaseAuthenticationHandler.cs
+++ b/src/HttpClientAuthentication/Handlers/BaseAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 namespace KISS.HttpClientAuthentication.Handlers

--- a/src/HttpClientAuthentication/Handlers/BasicAuthenticationHandler.cs
+++ b/src/HttpClientAuthentication/Handlers/BasicAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using System.Net.Http.Headers;

--- a/src/HttpClientAuthentication/Handlers/NoAuthenticationHandler.cs
+++ b/src/HttpClientAuthentication/Handlers/NoAuthenticationHandler.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 namespace KISS.HttpClientAuthentication.Handlers

--- a/src/HttpClientAuthentication/Handlers/OAuth2AuthenticationHandler.cs
+++ b/src/HttpClientAuthentication/Handlers/OAuth2AuthenticationHandler.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using System.Net.Http.Headers;

--- a/src/HttpClientAuthentication/Helpers/AccessTokenResponse.cs
+++ b/src/HttpClientAuthentication/Helpers/AccessTokenResponse.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using System.Text.Json.Serialization;

--- a/src/HttpClientAuthentication/Helpers/ErrorResponse.cs
+++ b/src/HttpClientAuthentication/Helpers/ErrorResponse.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using System.Text.Json.Serialization;

--- a/src/HttpClientAuthentication/Helpers/IOAuth2Provider.cs
+++ b/src/HttpClientAuthentication/Helpers/IOAuth2Provider.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using KISS.HttpClientAuthentication.Configuration;

--- a/src/HttpClientAuthentication/Helpers/OAuth2Provider.cs
+++ b/src/HttpClientAuthentication/Helpers/OAuth2Provider.cs
@@ -117,11 +117,7 @@ namespace KISS.HttpClientAuthentication.Helpers
         private async Task<AccessTokenResponse?> ParseResponseAsync(OAuth2Configuration configuration, HttpResponseMessage result,
                                                                     CancellationToken cancellationToken)
         {
-#if NET6_0_OR_GREATER
             string body = await result.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-#else
-            string body = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
-#endif
 
             if (!result.IsSuccessStatusCode)
             {

--- a/src/HttpClientAuthentication/Helpers/OAuth2Provider.cs
+++ b/src/HttpClientAuthentication/Helpers/OAuth2Provider.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using System.Net;

--- a/src/HttpClientAuthentication/Helpers/OAuth2Provider.cs
+++ b/src/HttpClientAuthentication/Helpers/OAuth2Provider.cs
@@ -1,8 +1,8 @@
 // Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
+using System.Globalization;
 using System.Net;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using KISS.HttpClientAuthentication.Configuration;
@@ -23,48 +23,30 @@ namespace KISS.HttpClientAuthentication.Helpers
         /// <inheritdoc />
         public async ValueTask<AccessTokenResponse?> GetClientCredentialsAccessTokenAsync(OAuth2Configuration configuration, CancellationToken cancellationToken = default)
         {
-            if (configuration.GrantType is not OAuth2GrantType.ClientCredentials)
-            {
-                throw new ArgumentException($"{nameof(configuration.GrantType)} must be {OAuth2GrantType.ClientCredentials}.", nameof(configuration));
-            }
-
-            if (configuration.ClientCredentials is null)
-            {
-                throw new ArgumentException($"No valid {nameof(configuration.ClientCredentials)} found.", nameof(configuration));
-            }
-
-            if (string.IsNullOrWhiteSpace(configuration.ClientCredentials.ClientId))
-            {
-                throw new ArgumentException($"{nameof(configuration.ClientCredentials)}.{nameof(configuration.ClientCredentials.ClientId)} must be specified.",
-                                            nameof(configuration));
-            }
-
-            if (string.IsNullOrWhiteSpace(configuration.ClientCredentials.ClientSecret))
-            {
-                throw new ArgumentException($"{nameof(configuration.ClientCredentials)}.{nameof(configuration.ClientCredentials.ClientSecret)} must be specified.",
-                                            nameof(configuration));
-            }
-
+            ValidateClientCredentialParameters(configuration);
 
             string cacheKey = $"{configuration.GrantType}#{configuration.TokenEndpoint}#{configuration.ClientCredentials!.ClientId}";
 
-            if (memoryCache.TryGetValue(cacheKey, out AccessTokenResponse? token))
+            AccessTokenResponse? token;
+
+            if (!configuration.DisableTokenCache)
             {
-                logger.LogInformation("Token for {TokenEndpoint} with client id {ClientId} found in cache, using this.",
-                                      configuration.TokenEndpoint, configuration.ClientCredentials.ClientId);
-                return token;
+                if (memoryCache.TryGetValue(cacheKey, out token))
+                {
+                    logger.LogDebug("Token for {TokenEndpoint} with client id {ClientId} found in cache, using this.",
+                                          configuration.TokenEndpoint, configuration.ClientCredentials.ClientId);
+                    return token;
+                }
+
+                logger.LogDebug("Could not find existing token in cache, requesting token from endpoint {TokenEndpoint} with client id {ClientId}.",
+                            configuration.TokenEndpoint, configuration.ClientCredentials.ClientId);
             }
 
-            logger.LogDebug("Could not find existing token in cache, requesting token from endpoint {TokenEndpoint} with client id {ClientId}.",
-                            configuration.TokenEndpoint, configuration.ClientCredentials.ClientId);
+            using HttpRequestMessage request = GetTokenRequest(configuration);
 
-            using FormUrlEncodedContent requestContent = GetClientCredentialsContent(configuration.ClientCredentials!, configuration.Scope);
+            using HttpResponseMessage response = await _client.SendAsync(request, cancellationToken);
 
-            using HttpResponseMessage result = configuration.ClientCredentials!.UseBasicAuthorizationHeader
-                ? await PostWithBasicAuthenticationAsync(configuration, requestContent, cancellationToken).ConfigureAwait(false)
-                : await _client.PostAsync(configuration.TokenEndpoint, requestContent, cancellationToken).ConfigureAwait(false);
-
-            token = await ParseResponseAsync(configuration, result, cancellationToken).ConfigureAwait(false);
+            token = await ParseResponseAsync(configuration, response, cancellationToken).ConfigureAwait(false);
 
             if (token is null)
             {
@@ -73,7 +55,7 @@ namespace KISS.HttpClientAuthentication.Helpers
 
             if (configuration.DisableTokenCache)
             {
-                logger.LogInformation("Token retrieved from {TokenEndpoint} with client id {ClientId}, but the token cache is disabled.",
+                logger.LogDebug("Token retrieved from {TokenEndpoint} with client id {ClientId}, but the token cache is disabled.",
                                       configuration.TokenEndpoint, configuration.ClientCredentials!.ClientId);
             }
             else if (token.ExpiresIn > 0)
@@ -81,51 +63,107 @@ namespace KISS.HttpClientAuthentication.Helpers
                 double cacheExpiresIn = (int)token.ExpiresIn * 0.95;
                 memoryCache.Set(cacheKey, token, TimeSpan.FromSeconds(cacheExpiresIn));
 
-                logger.LogInformation("Token retrieved from {TokenEndpoint} with client id {ClientId} and cached for {CacheExpiresIn} seconds.",
+                logger.LogDebug("Token retrieved from {TokenEndpoint} with client id {ClientId} and cached for {CacheExpiresIn} seconds.",
                                       configuration.TokenEndpoint, configuration.ClientCredentials!.ClientId, cacheExpiresIn);
             }
             else
             {
-                logger.LogInformation("Token retrieved from {TokenEndpoint} with client id {ClientId}, but not cached since it is missing expires_in information.",
+                logger.LogDebug("Token retrieved from {TokenEndpoint} with client id {ClientId}, but not cached since it is missing expires_in information.",
                                       configuration.TokenEndpoint, configuration.ClientCredentials!.ClientId);
             }
 
             return token;
         }
 
-        private static FormUrlEncodedContent GetClientCredentialsContent(ClientCredentialsConfiguration configuration, string? scope)
+        private static void AddTokenRequestHeaders(HttpRequestMessage request, OAuth2Configuration configuration)
+        {
+            if (configuration.ClientCredentials!.UseBasicAuthorizationHeader)
+            {
+                string encodedAuthorization = Convert.ToBase64String(
+                    Encoding.ASCII.GetBytes($"{configuration.ClientCredentials!.ClientId}:{configuration.ClientCredentials.ClientSecret}"));
+
+                request.Headers.Authorization = new("Basic", encodedAuthorization);
+            }
+
+            foreach (KeyValuePair<string, string> parameter in configuration.TokenEndpoint.AdditionalHeaderParameters)
+            {
+                request.Headers.Add(parameter.Key, parameter.Value);
+            }
+        }
+
+        private static FormUrlEncodedContent GetClientCredentialsContent(OAuth2Configuration configuration)
         {
             Dictionary<string, string> requestBody = new()
             {
                 { OAuth2Keyword.GrantType, OAuth2Keyword.ClientCredentials }
             };
 
-            if (!configuration.UseBasicAuthorizationHeader)
+            if (!configuration.ClientCredentials!.UseBasicAuthorizationHeader)
             {
-                requestBody.Add(OAuth2Keyword.ClientId, configuration.ClientId);
-                requestBody.Add(OAuth2Keyword.ClientSecret, configuration.ClientSecret);
+                requestBody.Add(OAuth2Keyword.ClientId, configuration.ClientCredentials.ClientId);
+                requestBody.Add(OAuth2Keyword.ClientSecret, configuration.ClientCredentials.ClientSecret);
             }
 
-            if (!string.IsNullOrWhiteSpace(scope))
+            if (!string.IsNullOrWhiteSpace(configuration.Scope))
             {
-                requestBody.Add(OAuth2Keyword.Scope, scope!.Trim());
+                requestBody.Add(OAuth2Keyword.Scope, configuration.Scope.Trim());
             }
 
-            return new FormUrlEncodedContent(requestBody!);
+            foreach (KeyValuePair<string, string> parameter in configuration.TokenEndpoint.AdditionalBodyParameters)
+            {
+                requestBody.Add(parameter.Key, parameter.Value);
+            }
+
+            return new FormUrlEncodedContent(requestBody);
         }
 
-        private async Task<AccessTokenResponse?> ParseResponseAsync(OAuth2Configuration configuration, HttpResponseMessage result,
+        private static Uri GetCompleteTokenUrl(OAuth2Endpoint tokenEndpoint)
+        {
+            if (tokenEndpoint.AdditionalQueryParameters.Count == 0)
+            {
+                return tokenEndpoint.Url;
+            }
+
+            UriBuilder uriBuilder = new(tokenEndpoint.Url);
+
+            StringBuilder stringBuilder = new();
+
+            foreach (KeyValuePair<string, string> parameter in tokenEndpoint.AdditionalQueryParameters)
+            {
+                stringBuilder.Append(CultureInfo.InvariantCulture, $"{parameter.Key}={WebUtility.UrlEncode(parameter.Value)}");
+            }
+
+            stringBuilder.Replace("&", "?", 0, 1);
+
+            uriBuilder.Query = stringBuilder.ToString();
+
+            return uriBuilder.Uri;
+        }
+
+        private static HttpRequestMessage GetTokenRequest(OAuth2Configuration configuration)
+        {
+            HttpRequestMessage request = new(HttpMethod.Get, GetCompleteTokenUrl(configuration.TokenEndpoint))
+            {
+                Method = HttpMethod.Post,
+                Content = GetClientCredentialsContent(configuration)
+            };
+
+            AddTokenRequestHeaders(request, configuration);
+            return request;
+        }
+
+        private async Task<AccessTokenResponse?> ParseResponseAsync(OAuth2Configuration configuration, HttpResponseMessage response,
                                                                     CancellationToken cancellationToken)
         {
-            string body = await result.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            string body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
-            if (!result.IsSuccessStatusCode)
+            if (!response.IsSuccessStatusCode)
             {
-                if (result.StatusCode != HttpStatusCode.BadRequest ||
-                    !TryParseAndLogOAuth2Error(body, configuration.TokenEndpoint, configuration.ClientCredentials!.ClientId))
+                if (response.StatusCode != HttpStatusCode.BadRequest ||
+                    !TryParseAndLogOAuth2Error(body, configuration.TokenEndpoint.Url, configuration.ClientCredentials!.ClientId))
                 {
                     logger.LogError("Could not authenticate against {TokenEndpoint}, the returned status code was {StatusCode}. Response body: {Body}.",
-                                    configuration.TokenEndpoint, result.StatusCode, body);
+                                    configuration.TokenEndpoint, response.StatusCode, body);
                 }
 
                 return null;
@@ -148,26 +186,6 @@ namespace KISS.HttpClientAuthentication.Helpers
             }
 
             return token;
-        }
-
-        private async Task<HttpResponseMessage> PostWithBasicAuthenticationAsync(OAuth2Configuration configuration, FormUrlEncodedContent requestContent,
-                                                                           CancellationToken cancellationToken)
-        {
-            string encodedAuthorization = Convert.ToBase64String(
-                Encoding.ASCII.GetBytes($"{configuration.ClientCredentials!.ClientId}:{configuration.ClientCredentials.ClientSecret}"));
-
-            using HttpRequestMessage request = new()
-            {
-                Content = requestContent,
-                Method = HttpMethod.Post,
-                RequestUri = configuration.TokenEndpoint,
-                Headers =
-                {
-                    Authorization = new AuthenticationHeaderValue("Basic", encodedAuthorization)
-                }
-            };
-
-            return await _client.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         private bool TryParseAndLogOAuth2Error(string errorContent, Uri tokenEndpoint, string? clientId)
@@ -219,6 +237,41 @@ namespace KISS.HttpClientAuthentication.Helpers
 #pragma warning restore CA2254 // Template should be a static expression
 
             return true;
+        }
+
+        private static void ValidateClientCredentialParameters(OAuth2Configuration configuration)
+        {
+            if (configuration.GrantType is not OAuth2GrantType.ClientCredentials)
+            {
+                throw new ArgumentException($"{nameof(configuration.GrantType)} must be {OAuth2GrantType.ClientCredentials}.", nameof(configuration));
+            }
+
+            if (configuration.ClientCredentials is null)
+            {
+                throw new ArgumentException($"{nameof(configuration.ClientCredentials)} is null.", nameof(configuration));
+            }
+
+            if (string.IsNullOrWhiteSpace(configuration.ClientCredentials.ClientId))
+            {
+                throw new ArgumentException($"{nameof(configuration.ClientCredentials)}.{nameof(configuration.ClientCredentials.ClientId)} must be specified.",
+                                            nameof(configuration));
+            }
+
+            if (string.IsNullOrWhiteSpace(configuration.ClientCredentials.ClientSecret))
+            {
+                throw new ArgumentException($"{nameof(configuration.ClientCredentials)}.{nameof(configuration.ClientCredentials.ClientSecret)} must be specified.",
+                                            nameof(configuration));
+            }
+
+            if (configuration.TokenEndpoint is null)
+            {
+                throw new ArgumentException($"{nameof(configuration.TokenEndpoint)} is null.", nameof(configuration));
+            }
+
+            if (configuration.TokenEndpoint.Url is null)
+            {
+                throw new ArgumentException($"{nameof(configuration.TokenEndpoint)}.{nameof(configuration.TokenEndpoint.Url)} must be specified.", nameof(configuration));
+            }
         }
     }
 }

--- a/src/HttpClientAuthentication/HttpClientAuthentication.csproj
+++ b/src/HttpClientAuthentication/HttpClientAuthentication.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <AssemblyName>KISS.HttpClientAuthentication</AssemblyName>
     <RootNamespace>KISS.HttpClientAuthentication</RootNamespace>
 
@@ -9,9 +9,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
 
     <!-- Ensure bump this when working on new version-->
-    <VersionPrefix>2.0.2</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Rune Gulbrandsen</Authors>
-    <Copyright>Copyright (c) 2024 Rune Gulbrandsen. All rights reserved.</Copyright>
+    <Copyright>Copyright (c) 2025 Rune Gulbrandsen. All rights reserved.</Copyright>
     <Summary>
         Extension methods to apply authentication handling to HttpClient based on configuration from 
         .NET configuration providers.
@@ -23,20 +23,19 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[6.0.0,7.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[6.0.2,7.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[6.0.0,7.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="[6.0.0,7.0.0)" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[8.0.2,9.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="[8.0.1,9.0.0)" />
+    <PackageReference Include="System.Text.Json" Version="[8.0.5,9.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HttpClientAuthentication/HttpClientAuthenticationExtensions.cs
+++ b/src/HttpClientAuthentication/HttpClientAuthenticationExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using KISS.HttpClientAuthentication.Configuration;

--- a/src/HttpClientAuthentication/HttpClientAuthenticationExtensions.cs
+++ b/src/HttpClientAuthentication/HttpClientAuthenticationExtensions.cs
@@ -50,20 +50,8 @@ namespace KISS.HttpClientAuthentication
         /// </exception>
         public static IHttpClientBuilder AddAuthenticatedHttpMessageHandler(this IHttpClientBuilder builder, string configSection)
         {
-#if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(builder);
             ArgumentNullException.ThrowIfNull(configSection);
-#else
-            if (builder is null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            if (configSection is null)
-            {
-                throw new ArgumentNullException(nameof(configSection));
-            }
-#endif
 
             builder.Services.AddMemoryCache();
 

--- a/test/HttpClientAuthentication.Test/AssemblyInfo.cs
+++ b/test/HttpClientAuthentication.Test/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 [assembly: CLSCompliant(false)]

--- a/test/HttpClientAuthentication.Test/Handlers/ApiKeyAuthenticationHandlerTests.cs
+++ b/test/HttpClientAuthentication.Test/Handlers/ApiKeyAuthenticationHandlerTests.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using FluentAssertions;

--- a/test/HttpClientAuthentication.Test/Handlers/BasicAuthenticationHandlerTests.cs
+++ b/test/HttpClientAuthentication.Test/Handlers/BasicAuthenticationHandlerTests.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using System.Text;

--- a/test/HttpClientAuthentication.Test/Handlers/HandlerTestBase.cs
+++ b/test/HttpClientAuthentication.Test/Handlers/HandlerTestBase.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using System.Net;

--- a/test/HttpClientAuthentication.Test/Handlers/OAuth2AuthenticationHandlerTests.cs
+++ b/test/HttpClientAuthentication.Test/Handlers/OAuth2AuthenticationHandlerTests.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using FluentAssertions;

--- a/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/GetClientCredentialsAccessTokenAsyncTests.cs
+++ b/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/GetClientCredentialsAccessTokenAsyncTests.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using System.Net;

--- a/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/GetClientCredentialsAccessTokenAsyncTests.cs
+++ b/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/GetClientCredentialsAccessTokenAsyncTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text;
 using FluentAssertions;
-using FluentAssertions.Execution;
 using KISS.HttpClientAuthentication.Configuration;
 using KISS.HttpClientAuthentication.Constants;
 using KISS.HttpClientAuthentication.Helpers;
@@ -38,7 +37,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             Func<Task> act = () => provider.GetClientCredentialsAccessTokenAsync(new() { GrantType = OAuth2GrantType.ClientCredentials }, default!)
                                            .AsTask();
 
-            await act.Should().ThrowAsync<ArgumentException>().WithParameterName("configuration").WithMessage("No valid ClientCredentials found.*");
+            await act.Should().ThrowAsync<ArgumentException>().WithParameterName("configuration").WithMessage("ClientCredentials is null.*");
         }
 
         [Theory]
@@ -54,7 +53,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = clientId!,
@@ -83,7 +82,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -97,6 +96,43 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             await act.Should().ThrowAsync<ArgumentException>()
                               .WithParameterName("configuration")
                               .WithMessage("ClientCredentials.ClientSecret must be specified.*");
+        }
+
+        [Fact]
+        public async Task TestMissingTokenEndpointConfigurationSectionThrowsArgumentException()
+        {
+            OAuth2Provider provider = BuildServices().GetRequiredService<OAuth2Provider>();
+
+            Func<Task> act = () => provider.GetClientCredentialsAccessTokenAsync(new()
+            {
+                GrantType = OAuth2GrantType.ClientCredentials,
+                ClientCredentials = new()
+                {
+                    ClientId = "client_id",
+                    ClientSecret = "client_secret"
+                }
+            }, default!).AsTask();
+
+            await act.Should().ThrowAsync<ArgumentException>().WithParameterName("configuration").WithMessage("TokenEndpoint is null.*");
+        }
+
+        [Fact]
+        public async Task TestMissingTokenEndpointUrlThrowsArgumentException()
+        {
+            OAuth2Provider provider = BuildServices().GetRequiredService<OAuth2Provider>();
+
+            Func<Task> act = () => provider.GetClientCredentialsAccessTokenAsync(new()
+            {
+                GrantType = OAuth2GrantType.ClientCredentials,
+                ClientCredentials = new()
+                {
+                    ClientId = "client_id",
+                    ClientSecret = "client_secret"
+                },
+                TokenEndpoint = new()
+            }, default!).AsTask();
+
+            await act.Should().ThrowAsync<ArgumentException>().WithParameterName("configuration").WithMessage("TokenEndpoint.Url must be specified.*");
         }
 
         [Fact]
@@ -120,7 +156,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -138,7 +174,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<ILogger<OAuth2Provider>> loggerMock = services.GetRequiredService<Mock<ILogger<OAuth2Provider>>>();
 
-            loggerMock.VerifyExt(l => l.LogInformation("Token for {TokenEndpoint} with client id {ClientId} found in cache, using this.",
+            loggerMock.VerifyExt(l => l.LogDebug("Token for {TokenEndpoint} with client id {ClientId} found in cache, using this.",
                                                        "https://somehost/", "client_id"), Times.Once);
         }
 
@@ -165,7 +201,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -194,7 +230,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             loggerMock.VerifyExt(l => l.LogDebug("Could not find existing token in cache, requesting token from endpoint {TokenEndpoint} with client id {ClientId}.",
                                                  "https://somehost/", "client_id"), Times.Once);
 
-            loggerMock.VerifyExt(l => l.LogInformation("Token retrieved from {TokenEndpoint} with client id {ClientId} and cached for {CacheExpiresIn} seconds.",
+            loggerMock.VerifyExt(l => l.LogDebug("Token retrieved from {TokenEndpoint} with client id {ClientId} and cached for {CacheExpiresIn} seconds.",
                                                        "https://somehost/", "client_id", 3420), Times.Once);
         }
 
@@ -221,7 +257,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -238,7 +274,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<ILogger<OAuth2Provider>> loggerMock = services.GetRequiredService<Mock<ILogger<OAuth2Provider>>>();
 
-            loggerMock.VerifyExt(l => l.LogInformation("Token retrieved from {TokenEndpoint} with client id {ClientId}, but not cached since it is missing expires_in information.",
+            loggerMock.VerifyExt(l => l.LogDebug("Token retrieved from {TokenEndpoint} with client id {ClientId}, but not cached since it is missing expires_in information.",
                                                        "https://somehost/", "client_id"), Times.Once);
         }
 
@@ -265,7 +301,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -283,7 +319,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<ILogger<OAuth2Provider>> loggerMock = services.GetRequiredService<Mock<ILogger<OAuth2Provider>>>();
 
-            loggerMock.VerifyExt(l => l.LogInformation("Token retrieved from {TokenEndpoint} with client id {ClientId}, but the token cache is disabled.",
+            loggerMock.VerifyExt(l => l.LogDebug("Token retrieved from {TokenEndpoint} with client id {ClientId}, but the token cache is disabled.",
                                                        "https://somehost/", "client_id"), Times.Once);
         }
 
@@ -294,21 +330,24 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<HttpClient> httpClientMock = services.GetRequiredService<Mock<HttpClient>>();
 
-            httpClientMock.Setup(httpClient => httpClient.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
-                          .Callback(async (HttpRequestMessage request, CancellationToken _) =>
-                          {
-                              request.Should().NotBeNull("Missing SendAsync request.");
-                              request.Headers.Authorization.Should().BeNull();
+            HttpRequestMessage? actualRequest = null;
 
-                              string content = await request.Content!.ReadAsStringAsync(default);
-                              content.Should().Be($"grant_type=client_credentials&client_id=client_id&client_secret=client_secret{Environment.NewLine}");
-                          })
-                          .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
+            httpClientMock.Setup(httpClient => httpClient.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                          .Callback((HttpRequestMessage request, CancellationToken _) => actualRequest = request)
+                          .ReturnsAsync(() =>
+                          {
+                              actualRequest!.Headers.Authorization.Should().BeNull();
+
+                              string content = actualRequest.Content!.ReadAsStringAsync(default).GetAwaiter().GetResult();
+                              content.Should().Be($"grant_type=client_credentials&client_id=client_id&client_secret=client_secret");
+
+                              return new HttpResponseMessage(HttpStatusCode.NotFound);
+                          });
 
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -328,29 +367,26 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<HttpClient> httpClientMock = services.GetRequiredService<Mock<HttpClient>>();
 
-            HttpRequestMessage? actualRequest = null!;
+            HttpRequestMessage? actualRequest = null;
 
             httpClientMock.Setup(httpClient => httpClient.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
-                          .Callback(async (HttpRequestMessage request, CancellationToken _) =>
+                          .Callback((HttpRequestMessage request, CancellationToken _) => actualRequest = request)
+                          .ReturnsAsync(() =>
                           {
-                              actualRequest.Should().NotBeNull("Missing SendAsync request.");
-                              actualRequest.Headers.Authorization.Should().NotBeNull();
+                              actualRequest!.Headers.Authorization.Should().NotBeNull();
 
-                              using (new AssertionScope())
-                              {
-                                  actualRequest.Headers.Authorization!.Scheme.Should().Be("Basic");
-                                  actualRequest.Headers.Authorization!.Parameter.Should().Be(Convert.ToBase64String(Encoding.ASCII.GetBytes($"client_id:client_secret")));
-                              }
+                              actualRequest.Headers.Authorization!.Scheme.Should().Be("Basic");
+                              actualRequest.Headers.Authorization!.Parameter.Should().Be(Convert.ToBase64String(Encoding.ASCII.GetBytes($"client_id:client_secret")));
 
-                              string content = await request.Content!.ReadAsStringAsync(default);
-                              content.Should().Be($"grant_type=client_credentials{Environment.NewLine}");
-                          })
-                          .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
+                              string content = actualRequest.Content!.ReadAsStringAsync(default).GetAwaiter().GetResult();
+                              content.Should().Be($"grant_type=client_credentials");
+                              return new HttpResponseMessage(HttpStatusCode.NotFound);
+                          });
 
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     UseBasicAuthorizationHeader = true,
@@ -371,21 +407,24 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<HttpClient> httpClientMock = services.GetRequiredService<Mock<HttpClient>>();
 
-            httpClientMock.Setup(httpClient => httpClient.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
-                          .Callback(async (HttpRequestMessage request, CancellationToken _) =>
-                          {
-                              request.Should().NotBeNull("Missing SendAsync request.");
-                              request.Headers.Authorization.Should().BeNull();
+            HttpRequestMessage? actualRequest = null;
 
-                              string content = await request.Content!.ReadAsStringAsync(default);
-                              content.Should().Be($"*scope=test_scope*");
-                          })
-                          .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
+            httpClientMock.Setup(httpClient => httpClient.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                          .Callback((HttpRequestMessage request, CancellationToken _) => actualRequest = request)
+                          .ReturnsAsync(() =>
+                          {
+                              actualRequest!.Headers.Authorization.Should().BeNull();
+
+                              string content = actualRequest.Content!.ReadAsStringAsync(default).GetAwaiter().GetResult();
+                              content.Should().Contain($"scope=test_scope");
+
+                              return new HttpResponseMessage(HttpStatusCode.NotFound);
+                          });
 
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -410,27 +449,87 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<HttpClient> httpClientMock = services.GetRequiredService<Mock<HttpClient>>();
 
-            httpClientMock.Setup(httpClient => httpClient.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
-                          .Callback(async (HttpRequestMessage request, CancellationToken _) =>
-                          {
-                              request.Should().NotBeNull("Missing SendAsync request.");
-                              request.Headers.Authorization.Should().BeNull();
+            HttpRequestMessage? actualRequest = null;
 
-                              string content = await request.Content!.ReadAsStringAsync(default);
-                              content.Should().NotBe($"*scope=*");
-                          })
-                          .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
+            httpClientMock.Setup(httpClient => httpClient.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                          .Callback((HttpRequestMessage request, CancellationToken _) => actualRequest = request)
+                          .ReturnsAsync(() =>
+                          {
+                              actualRequest!.Headers.Authorization.Should().BeNull();
+
+                              string content = actualRequest.Content!.ReadAsStringAsync(default).GetAwaiter().GetResult();
+                              content.Should().NotContain($"scope=");
+
+                              return new HttpResponseMessage(HttpStatusCode.NotFound);
+                          });
 
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
                     ClientSecret = "client_secret",
                 },
                 Scope = scope
+            };
+
+            OAuth2Provider provider = services.GetRequiredService<OAuth2Provider>();
+
+            await provider.GetClientCredentialsAccessTokenAsync(configuration, default);
+        }
+
+
+        [Fact]
+        public async Task TestRequestContainsAdditionalParametersSpecified()
+        {
+            IServiceProvider services = BuildServices();
+
+            Mock<HttpClient> httpClientMock = services.GetRequiredService<Mock<HttpClient>>();
+
+            HttpRequestMessage? actualRequest = null;
+
+            httpClientMock.Setup(httpClient => httpClient.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                          .Callback((HttpRequestMessage request, CancellationToken _) => actualRequest = request)
+                          .ReturnsAsync(() =>
+                          {
+                              actualRequest!.RequestUri!.Query.Should().Be("?query=query_value_with_%3F");
+
+                              actualRequest.Headers.Should().Contain(kvp =>
+                                kvp.Key == "header" && kvp.Value.All(v => "header_value".Equals(v)));
+
+                              string content = actualRequest.Content!.ReadAsStringAsync(default).GetAwaiter().GetResult();
+
+                              content.Should().Contain("body=body_value");
+
+                              return new HttpResponseMessage(HttpStatusCode.NotFound);
+                          });
+
+            OAuth2Configuration configuration = new()
+            {
+                GrantType = OAuth2GrantType.ClientCredentials,
+                TokenEndpoint = new()
+                {
+                    Url = new("https://somehost/"),
+                    AdditionalBodyParameters =
+                    {
+                        { "body", "body_value" }
+                    },
+                    AdditionalHeaderParameters =
+                    {
+                        { "header", "header_value" }
+                    },
+                    AdditionalQueryParameters =
+                    {
+                        { "query", "query_value_with_?" }
+                    }
+                },
+                ClientCredentials = new()
+                {
+                    ClientId = "client_id",
+                    ClientSecret = "client_secret"
+                }
             };
 
             OAuth2Provider provider = services.GetRequiredService<OAuth2Provider>();

--- a/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/GetClientCredentialsAccessTokenAsyncTests.cs
+++ b/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/GetClientCredentialsAccessTokenAsyncTests.cs
@@ -54,7 +54,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = clientId!,
@@ -83,7 +83,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -120,7 +120,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -138,7 +138,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<ILogger<OAuth2Provider>> loggerMock = services.GetRequiredService<Mock<ILogger<OAuth2Provider>>>();
 
-            loggerMock.VerifyExt(l => l.LogInformation("Token for {AuthorizationEndpoint} with client id {ClientId} found in cache, using this.",
+            loggerMock.VerifyExt(l => l.LogInformation("Token for {TokenEndpoint} with client id {ClientId} found in cache, using this.",
                                                        "https://somehost/", "client_id"), Times.Once);
         }
 
@@ -165,7 +165,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -191,10 +191,10 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<ILogger<OAuth2Provider>> loggerMock = services.GetRequiredService<Mock<ILogger<OAuth2Provider>>>();
 
-            loggerMock.VerifyExt(l => l.LogDebug("Could not find existing token in cache, requesting token from endpoint {AuthorizationEndpoint} with client id {ClientId}.",
+            loggerMock.VerifyExt(l => l.LogDebug("Could not find existing token in cache, requesting token from endpoint {TokenEndpoint} with client id {ClientId}.",
                                                  "https://somehost/", "client_id"), Times.Once);
 
-            loggerMock.VerifyExt(l => l.LogInformation("Token retrieved from {AuthorizationEndpoint} with client id {ClientId} and cached for {CacheExpiresIn} seconds.",
+            loggerMock.VerifyExt(l => l.LogInformation("Token retrieved from {TokenEndpoint} with client id {ClientId} and cached for {CacheExpiresIn} seconds.",
                                                        "https://somehost/", "client_id", 3420), Times.Once);
         }
 
@@ -221,7 +221,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -238,7 +238,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<ILogger<OAuth2Provider>> loggerMock = services.GetRequiredService<Mock<ILogger<OAuth2Provider>>>();
 
-            loggerMock.VerifyExt(l => l.LogInformation("Token retrieved from {AuthorizationEndpoint} with client id {ClientId}, but not cached since it is missing expires_in information.",
+            loggerMock.VerifyExt(l => l.LogInformation("Token retrieved from {TokenEndpoint} with client id {ClientId}, but not cached since it is missing expires_in information.",
                                                        "https://somehost/", "client_id"), Times.Once);
         }
 
@@ -265,7 +265,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -283,7 +283,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<ILogger<OAuth2Provider>> loggerMock = services.GetRequiredService<Mock<ILogger<OAuth2Provider>>>();
 
-            loggerMock.VerifyExt(l => l.LogInformation("Token retrieved from {AuthorizationEndpoint} with client id {ClientId}, but the token cache is disabled.",
+            loggerMock.VerifyExt(l => l.LogInformation("Token retrieved from {TokenEndpoint} with client id {ClientId}, but the token cache is disabled.",
                                                        "https://somehost/", "client_id"), Times.Once);
         }
 
@@ -308,7 +308,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -350,7 +350,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     UseBasicAuthorizationHeader = true,
@@ -385,7 +385,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -424,7 +424,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",

--- a/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/ParseResponseAsyncTests.cs
+++ b/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/ParseResponseAsyncTests.cs
@@ -41,7 +41,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -81,7 +81,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 AuthorizationScheme = "Authorization_Scheme",
                 ClientCredentials = new()
                 {
@@ -110,7 +110,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -146,7 +146,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",

--- a/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/ParseResponseAsyncTests.cs
+++ b/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/ParseResponseAsyncTests.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using System.Net;

--- a/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/ParseResponseAsyncTests.cs
+++ b/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/ParseResponseAsyncTests.cs
@@ -41,7 +41,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -81,7 +81,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 AuthorizationScheme = "Authorization_Scheme",
                 ClientCredentials = new()
                 {
@@ -110,7 +110,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -126,7 +126,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<ILogger<OAuth2Provider>> loggerMock = services.GetRequiredService<Mock<ILogger<OAuth2Provider>>>();
 
-            loggerMock.VerifyExt(l => l.LogError("Could not authenticate against {AuthorizationEndpoint}, the returned status code was {StatusCode}. Response body: {Body}.",
+            loggerMock.VerifyExt(l => l.LogError("Could not authenticate against {TokenEndpoint}, the returned status code was {StatusCode}. Response body: {Body}.",
                                                  "https://somehost/", HttpStatusCode.NotFound, "ERROR_BODY"), Times.Once);
         }
 
@@ -146,7 +146,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -162,7 +162,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<ILogger<OAuth2Provider>> loggerMock = services.GetRequiredService<Mock<ILogger<OAuth2Provider>>>();
 
-            loggerMock.VerifyExt(l => l.LogError("The result from {AuthorizationEndpoint} is not a valid OAuth2 result.", "https://somehost/"),
+            loggerMock.VerifyExt(l => l.LogError("The result from {TokenEndpoint} is not a valid OAuth2 result.", "https://somehost/"),
                                                  Times.Once);
         }
     }

--- a/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/TestBase.cs
+++ b/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/TestBase.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using KISS.HttpClientAuthentication.Helpers;

--- a/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/TryParseAndLogOAuth2ErrorTests.cs
+++ b/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/TryParseAndLogOAuth2ErrorTests.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using System.Net;

--- a/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/TryParseAndLogOAuth2ErrorTests.cs
+++ b/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/TryParseAndLogOAuth2ErrorTests.cs
@@ -37,7 +37,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -76,7 +76,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -115,7 +115,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -154,7 +154,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -191,7 +191,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                AuthorizationEndpoint = new("https://somehost/"),
+                TokenEndpoint = new("https://somehost/"),
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -207,7 +207,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
 
             Mock<ILogger<OAuth2Provider>> loggerMock = services.GetRequiredService<Mock<ILogger<OAuth2Provider>>>();
 
-            loggerMock.VerifyExt(l => l.LogError("Could not authenticate against {AuthorizationEndpoint}, the returned status code was {StatusCode}. Response body: {Body}.",
+            loggerMock.VerifyExt(l => l.LogError("Could not authenticate against {TokenEndpoint}, the returned status code was {StatusCode}. Response body: {Body}.",
                                                  "https://somehost/", HttpStatusCode.BadRequest, content), Times.Once);
         }
     }

--- a/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/TryParseAndLogOAuth2ErrorTests.cs
+++ b/test/HttpClientAuthentication.Test/Helpers/OAuth2ProviderTests/TryParseAndLogOAuth2ErrorTests.cs
@@ -37,7 +37,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -76,7 +76,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -115,7 +115,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -154,7 +154,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",
@@ -191,7 +191,7 @@ namespace KISS.HttpClientAuthentication.Test.Helpers.OAuth2ProviderTests
             OAuth2Configuration configuration = new()
             {
                 GrantType = OAuth2GrantType.ClientCredentials,
-                TokenEndpoint = new("https://somehost/"),
+                TokenEndpoint = new() { Url = new("https://somehost/") },
                 ClientCredentials = new()
                 {
                     ClientId = "client_id",

--- a/test/HttpClientAuthentication.Test/HttpClientAuthentication.Test.csproj
+++ b/test/HttpClientAuthentication.Test/HttpClientAuthentication.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>KISS.HttpClientAuthentication.Test</AssemblyName>
     <RootNamespace>KISS.HttpClientAuthentication.Test</RootNamespace>
 
@@ -14,21 +14,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="KISS.Moq.Logger" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/HttpClientAuthentication.Test/HttpClientAuthenticationExtensionsTests.cs
+++ b/test/HttpClientAuthentication.Test/HttpClientAuthenticationExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright © 2024 Rune Gulbrandsen.
+// Copyright © 2025 Rune Gulbrandsen.
 // All rights reserved. Licensed under the MIT License; see LICENSE.txt.
 
 using FluentAssertions;


### PR DESCRIPTION
**NOTE:** Breaking changes

- Version bumped to 3.0.0.
- Updated support to .NET 9.
- Removed support for .NET 6.
- Added support for additional query string, header and body parameters that can be passed to the token endpoint.